### PR TITLE
changing centos to CentOS for dependencies install

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -25,7 +25,7 @@ class logentries::dependencies {
   }
 
   case $::operatingsystem {
-    'Fedora', 'fedora', 'RedHat', 'redhat', 'centos', 'Amazon': {
+    'Fedora', 'fedora', 'RedHat', 'redhat', 'CentOS', 'Amazon': {
 
       $rpmkey = '/etc/pki/rpm-gpg/RPM-GPG-KEY-logentries'
 


### PR DESCRIPTION
Fixed capitalization of CentOS.

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: No matching value for selector param 'CentOS' at /etc/puppet/environments/production/modules/logentries/manifests/dependencies.pp:49 on node 
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
[root@ ~]# facter -p operatingsystem
CentOS
