### PR TITLE
Fixing CentOS References / Removed Name from Module

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -44,8 +44,8 @@ class logentries::dependencies {
         descr    => "logentries $::operatingsystemrelease $::architecture Repository ",
         enabled  => 1,
         baseurl  => $::operatingsystem ? {
-          /(Fedora|fedora|RedHat|redhat|centos)/ =>  "http://rep.logentries.com/rh/${basearch}",
-          'Amazon'                               =>  "http://rep.logentries.com/amazon\${releasever}/\${basearch}",
+          /(Fedora|fedora|RedHat|redhat|centos|CentOS)/ =>  "http://rep.logentries.com/rh/${::architecture}",
+          'Amazon'                                      =>  "http://rep.logentries.com/amazon\${releasever}/\${basearch}",
         },
         gpgcheck => 1,
         gpgkey   => 'http://rep.logentries.com/RPM-GPG-KEY-logentries',

--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -25,7 +25,7 @@ class logentries::dependencies {
   }
 
   case $::operatingsystem {
-    'Fedora', 'fedora', 'RedHat', 'redhat', 'centos', 'Amazon': {
+    'Fedora', 'fedora', 'RedHat', 'redhat', 'CentOS', 'Amazon': {
 
       $rpmkey = '/etc/pki/rpm-gpg/RPM-GPG-KEY-logentries'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-class logentries($account_key, $le_name='', $hostname='', $region_flag='') {
+class logentries($account_key, $hostname='', $region_flag='') {
 
   require logentries::dependencies
 
@@ -25,8 +25,8 @@ class logentries($account_key, $le_name='', $hostname='', $region_flag='') {
     ensure  => latest,
   }
 
-  if ($le_name != '') {
-    $name_flag = "--name='${le_name}'"
+  if ($name != '') {
+    $name_flag = "--name='${name}'"
   }
 
   if ($hostname != '') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-class logentries($account_key, $name='', $hostname='', $region_flag='') {
+class logentries($account_key, $le_name='', $hostname='', $region_flag='') {
 
   require logentries::dependencies
 
@@ -25,8 +25,8 @@ class logentries($account_key, $name='', $hostname='', $region_flag='') {
     ensure  => latest,
   }
 
-  if ($name != '') {
-    $name_flag = "--name='${name}'"
+  if ($le_name != '') {
+    $name_flag = "--name='${le_name}'"
   }
 
   if ($hostname != '') {


### PR DESCRIPTION
facter saw as CentOS (at least in CentOS 6.4) but was looking for centos. Also definition of name in the class was throwing duplicate errors.