### PR TITLE
Use long key ID

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -79,7 +79,7 @@ class logentries::dependencies (
             location    => 'http://rep.logentries.com/',
             repos       => 'main',
             include_src => false,
-            key         => 'C43C79AD',
+            key         => 'FA7FA2E59A243096E1B4105DA5270289C43C79AD',
             key_server  => 'keyserver.ubuntu.com',
           }
         }


### PR DESCRIPTION
Switch to the long (40 character) key id because puppetlabs-apt 
module emits this warning when using the short key ID:

```
Warning: /Apt_key[Add key: C43C79AD from Apt::Source logentries]: The id
should be a full fingerprint (40 characters), see README.
```
