### PR TITLE
Define variables to avoid puppet "Unknown variable" warnings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,10 +28,14 @@ class logentries(
 
   if ($le_name != '') {
     $name_flag = "--name='${le_name}'"
+  } else {
+    $name_flag = undef
   }
 
   if ($le_hostname != '') {
     $hostname_flag = "--hostname='${le_hostname}'"
+  } else {
+    $hostname_flag = undef
   }
 
   package { [ 'logentries', 'logentries-daemon' ]:


### PR DESCRIPTION
Puppet 4.8.x prints warnings for Unknown variables. This PR resolves by declaring the variables.

This is the minimal change to fix the issue